### PR TITLE
fix: linting gcp-documentation

### DIFF
--- a/.github/linter-rules/.markdown-lint-config.yaml
+++ b/.github/linter-rules/.markdown-lint-config.yaml
@@ -19,7 +19,7 @@ MD004: false                  # Unordered list style
 MD007:
   indent: 2                   # Unordered list indentation
 MD013:
-  line_length: 400            # Line length 80 is far to short
+  line_length: 600            # Line length 80 is far too short
 MD024: false                  # no-duplicate-header, fails on CHANGELOG.md
 MD026:
   punctuation: ".,;:!。，；:"  # List of not allowed

--- a/Architecture/Addendum.md
+++ b/Architecture/Addendum.md
@@ -1,65 +1,64 @@
-# Google Cloud Resources Addendum 
+# Google Cloud Resources Addendum
 
-### Table of Contents
+## Table of Contents
 
-  - [Fun Links](#fun-links)
-  - [Config Controller](#set-up-config-controller)
-    - [Config Controller overview](#config-controller-overview)
-  - [Policy Controller](#policy-controller)
-    - [Policy Controller Overview](#policy-controller-overview)
-  - [Config Sync](#config-sync)
-    - [Config Sync overview](#config-sync-overview)
-    - [Tools and Utilities](#tools-and-utilities)
-  - [kpt](#kpt)
-  - [DNS](#dns)
-    - [General DNS knowledge](#general-dns-knowledge)
-    - [DNS overview](#dns-overview)
-    - [GCP DNS Key Terms](#gcp-dns-key-terms)
-    - [Google Cloud Specific Documentation](#google-cloud-specific-documentation)
-    - [DNS Zones](#dns-zones)
-    - [Internal DNS](#internal-dns)
-    - [Private Zones](#private-zones)
-      - [Options](#options)
-    - [Public, External DNS Zone](#public-external-dns-zone)
-      - [Anycast Resolution](#anycast-resolution)
-    - [Cross Project Binding](#cross-project-binding)
-  - [Cloud Armor](#cloud-armor)
-    - [Cloud Armor Overview ](#cloud-armor-overview-)
-      - [Cloud Armour Encompasses:](#cloud-armour-encompasses)
-      - [Cloud Armor Policies \& Ordering:](#cloud-armor-policies--ordering)
-      - [How it works:](#how-it-works)
-      - [Example Policy Scopes:](#example-policy-scopes)
-    - [Cloud Armor Documentation of Interest](#cloud-armor-documentation-of-interest)
-  - [Cloud Load Balancing](#cloud-load-balancing)
-    - [Cloud Load Balancing overview](#cloud-load-balancing-overview)
-  - [Firewall Rules Creation](#firewall-rules-creation)
-    - [VPC firewall rules overview](#vpc-firewall-rules-overview)
-  - [Vpc Service Controls](#vpc-service-controls)
-    - [VPC Service Controls Overview](#vpc-service-controls-overview)
-    - [*Important* Terminology](#important-terminology)
-    - [Quick Start](#quick-start)
-    - [General information](#general-information)
-    - [Access Context Levels](#access-context-levels)
-  - [Remote Access with IAP](#remote-access-with-iap)
-    - [IAP access into a VM ](#iap-access-into-a-vm)
-    - [IAP TCP forwarding overview](#iap-tcp-forwarding-overview)
-  
+- [Fun Links](#fun-links)
+- [Config Controller](#config-controller)
+  - [Config Controller overview](#config-controller-overview)
+- [Policy Controller](#policy-controller)
+  - [Policy Controller Overview](#policy-controller-overview)
+- [Config Sync](#config-sync)
+  - [Config Sync overview](#config-sync-overview)
+  - [Tools and Utilities](#tools-and-utilities)
+- [kpt](#kpt)
+- [DNS](#dns)
+  - [General DNS knowledge](#general-dns-knowledge)
+  - [DNS overview](#dns-overview)
+  - [GCP DNS Key Terms](#gcp-dns-key-terms)
+  - [Google Cloud Specific Documentation](#google-cloud-specific-documentation)
+  - [DNS Zones](#dns-zones)
+  - [Internal DNS](#internal-dns)
+  - [Private Zones](#private-zones)
+    - [Options](#options)
+  - [Public, External DNS Zone](#public-external-dns-zone)
+    - [Anycast Resolution](#anycast-resolution)
+  - [Cross Project Binding](#cross-project-binding)
+- [Cloud Armor](#cloud-armor)
+  - [Cloud Armor Overview](#cloud-armor-overview)
+    - [Cloud Armour Encompasses:](#cloud-armour-encompasses)
+    - [Cloud Armor Policies \& Ordering:](#cloud-armor-policies--ordering)
+    - [How it works:](#how-it-works)
+    - [Example Policy Scopes:](#example-policy-scopes)
+  - [Cloud Armor Documentation of Interest](#cloud-armor-documentation-of-interest)
+- [Cloud Load Balancing](#cloud-load-balancing)
+  - [Cloud Load Balancing overview](#cloud-load-balancing-overview)
+- [Firewall Rules Creation](#firewall-rules-creation)
+  - [VPC firewall rules overview](#vpc-firewall-rules-overview)
+- [Vpc Service Controls](#vpc-service-controls)
+  - [VPC Service Controls Overview](#vpc-service-controls-overview)
+  - [*Important* Terminology](#important-terminology)
+  - [Quick Start](#quick-start)
+  - [General information](#general-information)
+  - [Access Context Levels](#access-context-levels)
+- [Remote Access with IAP](#remote-access-with-iap)
+  - [IAP access into a VM](#iap-access-into-a-windows-vm)
+  - [IAP TCP forwarding overview](#iap-tcp-forwarding-overview)
+
 --------------------------------------
 
 ### Fun Links
 
 Enjoy!
 
-The ultimate [infographic on GCP products](https://googlecloudcheatsheet.withgoogle.com/) for Developers 
+The ultimate [infographic on GCP products](https://googlecloudcheatsheet.withgoogle.com/) for Developers
 
 Check your regions latency using [GPCping](https://gcping.com/)
 
-
-### Config Controller 
+### Config Controller
 
 #### [Config Controller Overview](https://cloud.google.com/anthos-config-management/docs/concepts/config-controller-overview)
 
-Config Controller provides a managed control plane, based on Kubernetes. In addition, Config Controller instances come pre-installed with Policy Controller, Config Sync, and Config Connector. By using these components, you can leverage the tools and workflows of Kubernetes to manage Google Cloud resources and achieve consistency by using a GitOps workflow. 
+Config Controller provides a managed control plane, based on Kubernetes. In addition, Config Controller instances come pre-installed with Policy Controller, Config Sync, and Config Connector. By using these components, you can leverage the tools and workflows of Kubernetes to manage Google Cloud resources and achieve consistency by using a GitOps workflow.
 To learn more, see the Config Controller overview.
 
 ### Policy Controller
@@ -67,23 +66,23 @@ To learn more, see the Config Controller overview.
 #### [Policy Controller Overview](https://cloud.google.com/anthos-config-management/docs/concepts/policy-controller)
 
 Policy Controller enables the enforcement of fully programmable policies for your clusters. These policies act as "guardrails" and prevent any changes to the configuration of the Kubernetes API from violating security, operational, or compliance controls.
-You can set policies to actively block non-compliant API requests, or simply to audit the configuration of your clusters and report violations. Policy Controller is based on the open source Open Policy Agent Gatekeeper - [OPA ](https://open-policy-agent.github.io/gatekeeper/website/docs/operations/) project and comes with a full library of pre-built policies for common security and compliance controls.
+You can set policies to actively block non-compliant API requests, or simply to audit the configuration of your clusters and report violations. Policy Controller is based on the open source Open Policy Agent Gatekeeper - [OPA](https://open-policy-agent.github.io/gatekeeper/website/docs/operations/) project and comes with a full library of pre-built policies for common security and compliance controls.
 In addition to actively controlling your Kubernetes environment, you can optionally use Policy Controller as a way to analyze configuration for compliance before deployment. This helps provide valuable feedback during the process of configuration changes and ensures any non-compliant changes are caught early before they might be rejected during application.
 
 ### Config Sync
 
-#### [Config Sync Overview](https://cloud.google.com/anthos-config-management/docs/config-sync-overview)  
+#### [Config Sync Overview](https://cloud.google.com/anthos-config-management/docs/config-sync-overview)
 
-Config Sync is a GitOps service offered as a part of Anthos. Config Sync is built on an open source core and lets cluster operators and platform administrators deploy configurations from a source of truth. The service has the flexibility to support one or many clusters and any number of repositories per cluster or namespace. The clusters can be in a hybrid or multi-cloud environment.  
+Config Sync is a GitOps service offered as a part of Anthos. Config Sync is built on an open source core and lets cluster operators and platform administrators deploy configurations from a source of truth. The service has the flexibility to support one or many clusters and any number of repositories per cluster or namespace. The clusters can be in a hybrid or multi-cloud environment.
 
-Config Sync continuously reconciles the state of Config Controller with files stored in one or more Git repositories. This GitOps strategy lets you manage and deploy common configurations with a process that is auditable, transactional, reviewable, and version-controlled.  
+Config Sync continuously reconciles the state of Config Controller with files stored in one or more Git repositories. This GitOps strategy lets you manage and deploy common configurations with a process that is auditable, transactional, reviewable, and version-controlled.
 
 Getting started with [Config Sync](https://cloud.google.com/anthos-config-management/docs/tutorials/config-sync-multi-repo)
 
 #### Tools and Utilities
 
-[Nomos](https://cloud.google.com/anthos-config-management/docs/how-to/nomos-command)  
-[Kubectl](https://cloud.google.com/anthos-config-management/docs/how-to/configure-config-sync-kubectl)  
+[Nomos](https://cloud.google.com/anthos-config-management/docs/how-to/nomos-command)
+[Kubectl](https://cloud.google.com/anthos-config-management/docs/how-to/configure-config-sync-kubectl)
 
 ### kpt
 
@@ -95,12 +94,11 @@ kpt [functions catalog](https://catalog.kpt.dev/?id=curated-functions-catalog)
 
 **Important:**  Please note that kpt is available through the gcloud components, however you may wish to use a specific version, or newer version than that is provided by the gcloud SDK.
 
-
 ### DNS
 
 #### [DNS Overview](https://cloud.google.com/dns/docs/dns-overview)
 
-High level overview of some of the Google Cloud resource types to accelerate the design and deployment of your *workload*.  
+High level overview of some of the Google Cloud resource types to accelerate the design and deployment of your *workload*.
 
 #### General DNS knowledge
 
@@ -116,7 +114,7 @@ High level overview of some of the Google Cloud resource types to accelerate the
 
 [Cloud DNS Overview](https://cloud.google.com/dns/docs/overview/)
 
-[Cloud Domains Overview](https://cloud.google.com/domains/docs/overview)  
+[Cloud Domains Overview](https://cloud.google.com/domains/docs/overview)
 
 #### DNS Zones
 
@@ -125,25 +123,26 @@ High level overview of some of the Google Cloud resource types to accelerate the
 Internal DNS names are names that Google Cloud creates automatically. Available in a single VPC by default, resolved by the metadata server (169.254.169.254). Google Cloud automatically creates, updates, and removes these DNS records. Please see [Internal DNS zone documentation](https://cloud.google.com/compute/docs/internal-dns).
 
 #### Private Zones
- 
+
 Managed custom domain names for virtual machines and other GCP resources without exposing the DNS data to the public internet. Please see [Private Zone Documentation](https://cloud.google.com/dns/docs/zones#create-private-zone).
 
 Unless you have specified an alternative name server in an outbound server policy, Google Cloud first attempts to find a record in a private zone (or forwarding zone or peering zone) authorized for your VPC network before it looks for the record in a public zone.
 
 ##### Options
 
-* [Forward Queries to another server](https://cloud.google.com/dns/docs/zones/forwarding-zones)
-* [DNS Peering](https://cloud.google.com/dns/docs/zones/peering-zones)
-* [Managed Reverse Lookup Zone](https://cloud.google.com/dns/docs/zones/managed-reverse-lookup-zones)
+- [Forward Queries to another server](https://cloud.google.com/dns/docs/zones/forwarding-zones)
+- [DNS Peering](https://cloud.google.com/dns/docs/zones/peering-zones)
+- [Managed Reverse Lookup Zone](https://cloud.google.com/dns/docs/zones/managed-reverse-lookup-zones)
 
 #### Public, External DNS Zone
 
-Create DNS records in public zones to publish your service on the internet. Please see [Public Zone Documentation](https://cloud.google.com/dns/docs/dns-overview#public_zone). 
+Create DNS records in public zones to publish your service on the internet. Please see [Public Zone Documentation](https://cloud.google.com/dns/docs/dns-overview#public_zone).
 
 ##### Anycast Resolution
->> Google DNS has some fame associated to it for it's resiliency and global availability properties, with publicly available resolvers such as:  
->>>  8.8.8.8  
->>>  8.8.8.4
+>>
+>> Google DNS has some fame associated to it for it's resiliency and global availability properties, with publicly available resolvers such as:
+>>> 8.8.8.8
+>>> 8.8.8.4
 
 These resolvers are *anycast addresses* with requests being routed to the nearest location advertising the address.
 
@@ -151,48 +150,48 @@ These resolvers are *anycast addresses* with requests being routed to the neares
 
 Cross project binding is used to manage private DNS zones that service another project in the same organization.
 
-[Cross project binding Overview](https://cloud.google.com/dns/docs/zones/zones-overview#cross-project_binding)  
+[Cross project binding Overview](https://cloud.google.com/dns/docs/zones/zones-overview#cross-project_binding)
 [Creating a Zone with cross project binding](https://cloud.google.com/dns/docs/zones/cross-project-binding)
 
 ### Cloud Armor
 
-#### [Cloud Armor Overview ](https://cloud.google.com/armor/docs/cloud-armor-overview)
+#### [Cloud Armor Overview](https://cloud.google.com/armor/docs/cloud-armor-overview)
 
-Google Cloud Armor is a DDoS and application defense service the helps protect your *service*. Cloud Armor is tightly coupled with the Global HTTPS(S) Cloud Load Balancer. Cloud Armor protects your network services, typically behind a load balancer from DOS and other web based attacks. Enforcement is managed at the edge Point of Presence (POP), as close to the source traffic as possible. Traffic can be filtered and defended against at layer 7 of the OSI model. 
+Google Cloud Armor is a DDoS and application defense service the helps protect your *service*. Cloud Armor is tightly coupled with the Global HTTPS(S) Cloud Load Balancer. Cloud Armor protects your network services, typically behind a load balancer from DOS and other web based attacks. Enforcement is managed at the edge Point of Presence (POP), as close to the source traffic as possible. Traffic can be filtered and defended against at layer 7 of the OSI model.
 
-##### Cloud Armour Encompasses:
+##### Cloud Armour Encompasses
 
-* Policies/Rules
-* Allowlist / Denylist IP's
+- Policies/Rules
+- Allowlist / Denylist IP's
 
-##### Cloud Armor Policies & Ordering:
+##### Cloud Armor Policies & Ordering
 
 - Rules (allow) [Priority 1]
 - Rules (Deny) [Priority 2]
 
-##### How it works:
+##### How it works
 
-* Create a policy with +1 rules
-    * Supply IP range(s) to apply rule to
-    * On rule/IP match: Allow/Deny traffic
-      * Overlap rules with different priorities
-    * Apply policy to Targets
-      * Target = Load balanced backend services  
+- Create a policy with +1 rules
+  - Supply IP range(s) to apply rule to
+  - On rule/IP match: Allow/Deny traffic
+    - Overlap rules with different priorities
+  - Apply policy to Targets
+    - Target = Load balanced backend services
 
-##### Example Policy Scopes:  
+##### Example Policy Scopes
 
-* Create multiple rules, overlapping to create finer grained rules.  
-* SQL Injection Prevention (CSS), Geo based access control.  
-* Allows edge traffic blocking.  
+- Create multiple rules, overlapping to create finer grained rules.
+- SQL Injection Prevention (CSS), Geo based access control.
+- Allows edge traffic blocking.
 
-####  Cloud Armor Documentation of Interest
+#### Cloud Armor Documentation of Interest
 
-[Use cases](https://cloud.google.com/armor/docs/common-use-cases)  
-[Security Policies](https://cloud.google.com/armor/docs/configure-security-policies#https-load-balancer)  
-[Rules Language Reference](https://cloud.google.com/armor/docs/rules-language-reference)  
-[Cloud Armor Standard VS Managed Protection Plus](https://cloud.google.com/armor/docs/managed-protection-overview#standard_versus_plus)  
+[Use cases](https://cloud.google.com/armor/docs/common-use-cases)
+[Security Policies](https://cloud.google.com/armor/docs/configure-security-policies#https-load-balancer)
+[Rules Language Reference](https://cloud.google.com/armor/docs/rules-language-reference)
+[Cloud Armor Standard VS Managed Protection Plus](https://cloud.google.com/armor/docs/managed-protection-overview#standard_versus_plus)
 
-### Cloud Load Balancing 
+### Cloud Load Balancing
 
 #### [Cloud Load Balancing Overview](https://cloud.google.com/load-balancing/docs/load-balancing-overview)
 
@@ -200,6 +199,7 @@ A load balancer distributes user traffic across multiple instances of your appli
 Cloud Load Balancing is a fully distributed, software-defined managed service. It isn't hardware-based, so you don't need to manage a physical load-balancing infrastructure.
 
 Google Cloud offers the following load-balancing features:
+
 - Single anycast IP address
 - Software-defined load balancing
 - Seamless autoscaling
@@ -208,20 +208,20 @@ Google Cloud offers the following load-balancing features:
 - Global and regional load balancing
 - Advanced feature support
 
-### Firewall Rules Creation 
+### Firewall Rules Creation
 
 #### [VPC Firewall Rules Overview](https://cloud.google.com/vpc/docs/firewalls)
 
 Virtual Private Cloud (VPC) firewall rules apply to a given project and network.
 VPC firewall rules let you allow or deny connections to or from virtual machine (VM) instances in your VPC network. Enabled VPC firewall rules are always enforced, protecting your instances regardless of their configuration and operating system, even if they have not started up.
 
-### VPC Service Controls  
+### VPC Service Controls
 
 #### [VPC Service Controls Overview](https://cloud.google.com/vpc-service-controls/docs/overview)
 
-#### *Important* [Terminology](https://cloud.google.com/vpc-service-controls/docs/overview#terminology) 
+#### *Important* [Terminology](https://cloud.google.com/vpc-service-controls/docs/overview#terminology)
 
-A service perimeter creates a security boundary around Google Cloud resources. You can configure a perimeter to control communications from virtual machines (VMs) to a Google Cloud service (API), and between Google Cloud services. A perimeter allows free communication within the perimeter but, by default, blocks communication to Google Cloud services across the perimeter. The perimeter does not block access to any third-party API or services in the internet. [Reference doc.](https://cloud.google.com/vpc-service-controls/docs/overview#isolate)  
+A service perimeter creates a security boundary around Google Cloud resources. You can configure a perimeter to control communications from virtual machines (VMs) to a Google Cloud service (API), and between Google Cloud services. A perimeter allows free communication within the perimeter but, by default, blocks communication to Google Cloud services across the perimeter. The perimeter does not block access to any third-party API or services in the internet. [Reference doc.](https://cloud.google.com/vpc-service-controls/docs/overview#isolate)
 
 #### Quick Start
 
@@ -229,10 +229,10 @@ A service perimeter creates a security boundary around Google Cloud resources. Y
 
 #### General information
 
-VPC service controls allow blocking or restriction of api services at the Project or VPC network level 
+VPC service controls allow blocking or restriction of api services at the Project or VPC network level
 
-- Protects against data exfiltration  
-- Create a perimeter  
+- Protects against data exfiltration
+- Create a perimeter
   - Apply to a Project
   - Add services to restrict such as the storage API
 
@@ -244,6 +244,7 @@ VPC service controls allow blocking or restriction of api services at the Projec
 
 IAP Desktop is a Windows application that lets you manage multiple Remote Desktop connections to Windows VM instances. IAP Desktop connects to VM instances by using Identity-Aware Proxy TCP forwarding and does not require VM instances to have a public IP address.
 Before you connect by using IAP Desktop, make sure that the following prerequisites are met:
+
 - You've configured your VPC to allow IAP traffic to your VM instance.
 - You've downloaded and installed IAP Desktop on your local computer.
 

--- a/Architecture/Repository Structure.md
+++ b/Architecture/Repository Structure.md
@@ -1,11 +1,14 @@
 # Repos Structure and Roles
+
 The diagram below shows all the infrastructure repository **types** and the **roles** that are granted to each team.
 ![img](img/tiers.png)
 
-# Gitops
+## Gitops
+
 The current solution is using [Config Sync](https://cloud.google.com/anthos-config-management/docs/config-sync-overview) with git repos to pull configurations for deploying GCP infrastructure.
 
 The diagram below describes the Gitops process that involves 2 repositories.
+
 - Infra
 - ConfigSync
 
@@ -17,43 +20,46 @@ The process to implement a code change goes like this:
 
 ![img](img/gitops.png)
 
-# Git
+## Git
 
 The git repos are organized in different categories:
+
 - `gcp-documentation` (this repo) contains documentation for the landing zone.
 - Deployment repos: two types exists, one to manage Config Sync repos, the other to store infrastructure configurations.
-    - `gcp-tier1-configsync` is where the initial `root-sync` object is pointing and is used to manage the root sync objects and versioning of the tier1 infrastructure in experimentation, dev, preprod and prod.
-    - `gcp-tier1-infra` contains the landing zone configs for dev, preprod and prod.
-    - `gcp-experimentation-tier1-infra` contains the landing zone configs for experimentation.
+  - `gcp-tier1-configsync` is where the initial `root-sync` object is pointing and is used to manage the root sync objects and versioning of the tier1 infrastructure in experimentation, dev, preprod and prod.
+  - `gcp-tier1-infra` contains the landing zone configs for dev, preprod and prod.
+  - `gcp-experimentation-tier1-infra` contains the landing zone configs for experimentation.
 - `gcp-tools` contains common scripts and pipeline templates used by repos above as a git submodule.
 - `gcp-blueprints-catalog` **private repo** contains SSC specific packages that are used to build a landing zone.
 
 TODO: tier2 and tier3 repos
 
 ## Deployment Repos
+
 These repos have a common directory structure with slight variations.
 
 Below is a brief explanation of key repo components.  Some directories include sub-directories for each environment it configures (experimentation, dev, preprod, prod).  For simplicity, they will be expressed below as `<env_subdirs>`.
 
 - `repo root`:
-    - `.azure-pipelines` or `.github`: pipelines YAML files.
-    - `bootstrap`: (only in the "infra" repos)
-        - `<env_subdirs>`: contains `.env` file needed to create the management project which includes the Config Controller GKE cluster.
-    - `deploy`: ("WET" folder) its content is automatically generated and must not be edited manually.
-        - `<env_subdirs>`: contains the hydrated YAML files to be deployed.  **This is the directory used by Config Sync.**
-    - `source-base`: ("DRY" folder) contains a collection of *unedited* packages that will be deployed to all environments.
-    - `source-customization`:
-        - `<env_subdirs>`: contains the customization files that will overwrite the base for the environment.  Directory and file names must be replicated.  For example, to customize `source-base/landing-zone/setters.yaml`, it should be copied, then edited, in `source-customization/<env_subdir>/landing-zone/setters.yaml`.
-    - `tools`: git submodule from [gcp-tools](https://github.com/ssc-spc-ccoe-cei/gcp-tools)
-    - `temp-workspace`: used temporarily during hydration, included in `.gitignore`.
-    - `pre-commit-config.yaml`: the pre-commit will trigger `tools/scripts/kpt/hydrate.sh` to ensure all changes to source-base and/or source-customization were hydrated.
-    - `modupdate.sh`: script to checkout the git submodules, i.e. tools.
-    - `modversions.yaml`: file used by modupdate.sh to specify which versions of git sub modules to checkout.
+  - `.azure-pipelines` or `.github`: pipelines YAML files.
+  - `bootstrap`: (only in the "infra" repos)
+    - `<env_subdirs>`: contains `.env` file needed to create the management project which includes the Config Controller GKE cluster.
+  - `deploy`: ("WET" folder) its content is automatically generated and must not be edited manually.
+    - `<env_subdirs>`: contains the hydrated YAML files to be deployed.  **This is the directory used by Config Sync.**
+  - `source-base`: ("DRY" folder) contains a collection of *unedited* packages that will be deployed to all environments.
+  - `source-customization`:
+    - `<env_subdirs>`: contains the customization files that will overwrite the base for the environment.  Directory and file names must be replicated.  For example, to customize `source-base/landing-zone/setters.yaml`, it should be copied, then edited, in `source-customization/<env_subdir>/landing-zone/setters.yaml`.
+  - `tools`: git submodule from [gcp-tools](https://github.com/ssc-spc-ccoe-cei/gcp-tools)
+  - `temp-workspace`: used temporarily during hydration, included in `.gitignore`.
+  - `pre-commit-config.yaml`: the pre-commit will trigger `tools/scripts/kpt/hydrate.sh` to ensure all changes to source-base and/or source-customization were hydrated.
+  - `modupdate.sh`: script to checkout the git submodules, i.e. tools.
+  - `modversions.yaml`: file used by modupdate.sh to specify which versions of git sub modules to checkout.
 
 **A repo template is available [here](https://github.com/ssc-spc-ccoe-cei/gcp-repo-template).**
 
 ### Git Submodule: `tools`
-As mentionned above, the [gcp-tools](https://github.com/ssc-spc-ccoe-cei/gcp-tools) repo is configured as a git submodule in `.gitmodules`.  This git configuration is limited to specifying a branch.
+
+As mentioned above, the [gcp-tools](https://github.com/ssc-spc-ccoe-cei/gcp-tools) repo is configured as a git submodule in `.gitmodules`.  This git configuration is limited to specifying a branch.
 
 To overcome this limitation and checkout a specific tag or commit SHA, run `modupdate.sh` to checkout the version configured in `modversions.yaml`.
 
@@ -62,6 +68,7 @@ To overcome this limitation and checkout a specific tag or commit SHA, run `modu
 The tools submodule contains a `hydrate.sh` script to hydrate the configs with `kpt`.  The script must be executed when any changes to `source-base` and/or `source-customization` are made.  It is configured to run as a pre-commit hook for local validation and also in a validation pipeline during PR creation.
 
 At a high level, the script will:
+
 1. For each environment (experimentation, dev, preprod, prod), check if `source-customization/` contains that sub directory.  If so:
     - Create a `temp-workspace/<env>` directory to copy the `source-base/` and then copy `source-customization/<env>/`, this adds customization specific to that environment.
     - Run `kpt fn render` and remove local configs in `temp-workspace/<env>`.

--- a/Developer/Guide.md
+++ b/Developer/Guide.md
@@ -12,7 +12,7 @@ This guide will provide the necessary information that any Application Developer
 
 SSC chose [Anthos Config Management](https://cloud.google.com/anthos/config-management) to manage the Infrastructure-as-code. ACM uses Kubernetes config connector manifest to control resources deployed in GCP. Most developers have some level of experience with Kubernetes manifest file format and should not feel lost when looking, for the first time, at a Kubernetes [config connector](https://cloud.google.com/config-connector/docs/reference/overview) resource definition.
 
-### The Anthos Config Management components are:
+### The Anthos Config Management components are
 
 ![ACM Components](img/acm-components.png)
 
@@ -40,44 +40,44 @@ Example of policy use cases
 
 ![config controller](img/config-controller.png)
 
-# Shared Services Canada - GCP Landing zone
+## Shared Services Canada - GCP Landing zone
 
 SSC has built 4 distinct GCP organizations to isolate each environment from each other. The environments are experimentation, DEV, PREPROD and PROD.
 
 ![organizations](img/organizations.png)
-
 
 ## Experimentation / Sandbox
 
   This environment provides a great level of flexibility and autonomy to application developers. The objective is really to allow you to experiment any GCP services without requiring the implication of the platform administrator.
 
   It meets [TBS Cloud Usage Profile 1](https://canada-ca.github.io/cloud-guardrails/EN/00_Applicable-Scope.html) requirements and only allows **Unclassified** workloads.
-  
-  ### Cost
+
+### Cost
 
   This project is linked to a GCP billing account owned by **"your organization"**.
-  
-  ### Permissions
+
+### Permissions
 
   Your team gets granted `Editor` role on the GCP project.
-  
-  ### Working with GCP
+
+### Working with GCP
 
   Interaction with GCP is possible through the [cloud console](https://console.cloud.google.com/) or using [Gcloud SDK](https://cloud.google.com/sdk/docs/) from [Cloud Shell](https://cloud.google.com/shell/docs/) or any other Linux or windows computer, you can also interact with the GCP API directly. To do so, you authenticate with your Google Cloud Identity `user` account.
 
-  ### Networking
+### Networking
 
   You project comes with an existing networking configuration. This configuration meets the 30 days [Guardrails](https://github.com/canada-ca/cloud-guardrails-gcp) requirements for experimentation (Guardrails 1,2,4,8,12). The `Editor` role grants you permissions to create, for example, firewall rule.
 
   Below is the list of networking resources that have been deployed in your experimentation project:
-  - VPC (flow logs enabled)
-  - Subnets (Montreal and Toronto regions)
-      - PAZ
-      - APPRZ
-      - DATARZ
-  - Route to the internet (resources requires a `network tag`)
-  - Cloud NAT
-  - DNS logging policy
+
+- VPC (flow logs enabled)
+- Subnets (Montreal and Toronto regions)
+  - PAZ
+  - APPRZ
+  - DATARZ
+- Route to the internet (resources requires a `network tag`)
+- Cloud NAT
+- DNS logging policy
 
   ![experimentation networking](img/experimentation-networking.png)
 
@@ -108,6 +108,7 @@ The landing zone uses 3 different tiers of git repositories to manage GCP resour
 As you saw in that diagram, the resources for your application are include in two tiers called "tier 2" and "tier 3". Tier 2 is where this landing zone differs from other traditional services by trying to simplify as much as possible the management of the application security while maintaining a very strong and secure control on the environment. You get one tier 2 repository for each tier 3 repository (one-to-one relationship). As an app developer/operator, you do have full control (contributor + reviewer) over your tier 3 repository, but you also have contributor role on the tier 2 repo thus implementing that simplified change management process. It is the Platform Admin and the Security Admin that will be reviewing and approving the PR.
 
 So, when you want a change implemented on your tier 2 repo, you have two options:
+
 1. create a branch on the tier 2 repo, make and commit your changes and then, open a pull request
 2. reach out to platform admin and determine a solution
 
@@ -134,12 +135,13 @@ TODO: provide more details once network design is finalized
 ![hld](img/networking-hld-env.png)
 
 ## Training
+
 - GCP
-    - Google Cloud Platform Fundamentals
-    - Developing Applications with Google Cloud
+  - Google Cloud Platform Fundamentals
+  - Developing Applications with Google Cloud
 
 - CCCS
-    - Cloud Computing in the GC: The SA&A Process
+  - Cloud Computing in the GC: The SA&A Process
 
 ## GCP Landing Zone Resource Addendum
 

--- a/Identity/Azure AD integration.md
+++ b/Identity/Azure AD integration.md
@@ -1,1 +1,3 @@
-PLACEHOLDER
+# Azure AD Integration (Placeholder Title)
+
+PLACEHOLDER TEXT

--- a/Identity/Breakglass account creation.md
+++ b/Identity/Breakglass account creation.md
@@ -1,1 +1,3 @@
-This document is not made available publicly
+# Breakglass Account Creation
+
+This document is not made available publicly.

--- a/Identity/Cloud Identity.md
+++ b/Identity/Cloud Identity.md
@@ -1,1 +1,3 @@
-PLACEHOLDER
+# Cloud Identity (Placeholder Title)
+
+PLACEHOLDER TEXT

--- a/Identity/README.md
+++ b/Identity/README.md
@@ -1,10 +1,13 @@
 # Creation of a Google Cloud Identity and a Google Cloud Platform Organization
-## Prerequisite :
+
+## Prerequisite
+
   none
 
 ## Process
+
 Below outlines the process that should be followed
 
 1. Create Google Cloud Identity
-2. Azure AD Integration (optionnal)
+2. Azure AD Integration (optional)
 3. Breakglass Accounts Creation

--- a/Landing Zone Developer/Workflow.md
+++ b/Landing Zone Developer/Workflow.md
@@ -1,1 +1,3 @@
-PLACEHOLDER
+# Workflow (Placeholder Title)
+
+PLACEHOLDER TEXT

--- a/Landing Zone Developer/gatekeeper-policies/README.md
+++ b/Landing Zone Developer/gatekeeper-policies/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
-This folder will contain gatekeeper relataed documentation.
+This folder will contain gatekeeper related documentation.
 
-https://github.com/open-policy-agent/gatekeeper
-https://open-policy-agent.github.io/gatekeeper/website/docs/
+<https://github.com/open-policy-agent/gatekeeper>
+<https://open-policy-agent.github.io/gatekeeper/website/docs/>

--- a/Landing Zone Developer/gatekeeper-policies/testing/gator-cli/README.md
+++ b/Landing Zone Developer/gatekeeper-policies/testing/gator-cli/README.md
@@ -2,7 +2,7 @@
 
 The Gator CLI can be used to test Gatekeeper `ConstraintTemplates` and `Constraints` locally.
 
-Details and latest information: https://open-policy-agent.github.io/gatekeeper/website/docs/gator
+Details and latest information: <https://open-policy-agent.github.io/gatekeeper/website/docs/gator>
 
 ## Installation
 
@@ -12,13 +12,13 @@ You have a few options to install the Gator CLI:
 
 - To build from source:
 
-    ```
+    ```shell
     go get github.com/open-policy-agent/gatekeeper/cmd/gator
     ```
 
 - Install with Homebrew:
 
-    ```
+    ```shell
     brew install gator
     ```
 
@@ -30,13 +30,13 @@ You specify inputs using the `--filename` or short `-f` flag. Supported extensio
 
 Example 1:
 
-```
+```shell
 cat my-manifest.yaml | gator test --filename=template-and-constraints-folder/
 ```
 
 Example 2:
 
-```
+```shell
 gator test -f=my-manifest.yaml -f=templates-and-constraints-folder/
 ```
 
@@ -46,19 +46,19 @@ Run the following example scenario:
 
 - Download the community-owned library of policies for the OPA Gatekeeper project.
 
-    ```
+    ```shell
     git clone https://github.com/open-policy-agent/gatekeeper-library.git
     ```
 
 - Switch to the following folder:
 
-    ```
+    ```shell
     cd gatekeeper-library/library/general/httpsonly
     ```
 
 - Run the tree command:
 
-    ```
+    ```shell
     tree
     .
     ├── kustomization.yaml
@@ -76,34 +76,37 @@ Run the following example scenario:
     └── template.yaml
     ```
 
-- Test the `example_allowed.yaml` manifest againsts the constraintemplate and constraint.
+- Test the `example_allowed.yaml` manifest against the constraintemplate and constraint.
 
-    ```
+    ```shell
     gator test -f=samples/ingress-https-only/example_allowed.yaml -f=template.yaml -f=samples/ingress-https-only/constraint.yaml
     ```
+
     This will not return any errors.
 
     **Tip:** Adding --output=json or --output=yaml will return a null value.
 
-    ```
+    ```shell
     gator test -f=samples/ingress-https-only/example_allowed.yaml -f=template.yaml -f=samples/ingress-https-only/constraint.yaml --output=json
 
     null
     ```
 
-    ```
+    ```shell
     gator test -f=samples/ingress-https-only/example_allowed.yaml -f=template.yaml -f=samples/ingress-https-only/constraint.yaml --output=yaml
 
     []
     ```
-- Test the `example_disallowed.yaml` manifest againsts the constraintemplate and constraint.
 
-    ```
+- Test the `example_disallowed.yaml` manifest against the constraintemplate and constraint.
+
+    ```shell
     gator test -f=samples/ingress-https-only/example_disallowed.yaml -f=template.yaml -f=samples/ingress-https-only/constraint.yaml
     ```
+
     This will return the following error:
 
-    ```
+    ```shell
     Message: "Ingress should be https. tls configuration and allow-http=false annotation are required for ingress-demo-disallowed"
     ```
 
@@ -117,11 +120,11 @@ Run the following example scenario:
 
 You can send the output to `yaml` or `json` format:
 
-```
+```shell
 gator test --filename=manifests-and-policies/ --output=json
 ```
 
-```
+```shell
 gator test --filename=manifests-and-policies/ --output=yaml
 ```
 
@@ -137,11 +140,11 @@ gator test --filename=manifests-and-policies/ --output=yaml
 | Tests  | A Test declares a ConstraintTemplate, a Constraint, and Cases to test the Constraint  |
 | Cases  | A Case defines an object to validate and whether the object is expected to pass validation  |
 
-
 ### Suites
+
 A valid Suite file declares the following:
 
-```
+```shell
 kind: Suite
 apiVersion: test.gatekeeper.sh/v1alpha1
 ```
@@ -162,39 +165,39 @@ A Case must specify assertions and whether it expects violations. The simplest w
 
 The Case expects at least one violation:
 
-```
+```shell
 assertions:
 - violations: yes
 ```
 
 The Case expects no violations:
 
-```
+```shell
 assertions:
 - violations: no
 ```
 
 **For further information visit:**
 
-https://open-policy-agent.github.io/gatekeeper/website/docs/gator#cases
+<https://open-policy-agent.github.io/gatekeeper/website/docs/gator#cases>
 
 ### Usage
 
 To run a specific suite:
 
-```
+```shell
 gator verify suite.yaml
 ```
 
 To run all suites in the current directory and all child directories recursively
 
-```
+```shell
 gator verify ./...
 ```
 
 To only run tests whose full names contain a match for a regular expression, use the run flag:
 
-```
+```shell
 gator verify path/to/suites/... --run "disallowed"
 ```
 
@@ -204,28 +207,28 @@ The following example will showcase the test suite that was built to evaluate th
 
 Gatekeeper policies are stored in the `gcp-blueprints-catalog`.
 
-The test suite, contraint, constrainttemplate, and tests can be found [here](https://dev.azure.com/gc-cpa/iac-gcp/_git/gcp-blueprints-catalog?path=/gatekeeper-policies/naming-rules/project).
+The test suite, constraint, constrainttemplate, and tests can be found [here](https://dev.azure.com/gc-cpa/iac-gcp/_git/gcp-blueprints-catalog?path=/gatekeeper-policies/naming-rules/project).
 
 The following steps can be used to create a test suite:
 
 - Create a file called `suite.yaml`.
 
-    - The following elements are important and define most of the suite file.
-        - kind
-        - apiVersion
-        - tests
-        - cases
-        - violations
-    - Set a name for the test suite under metadata - name.
-    - This example only contains two test cases: one for `allowed` values and the other for `not allowed` values.
-    - The `template.yaml` (ConstraintTemplate) and `constraint.yaml` (constraint) files should be in the same folder as the `suite.yaml` file.
-        - The resource manifests contained in the `tests/` folder are evaluated againsts the constraints set in the `template.yaml` and `constraint.yaml` files.
-    - Tests are manifest files containing example projects and are placed under `tests/`.
-        - The `tests/project_allowed.yaml` manifest contains a project resource with a valid name while the `tests/project_not_allowed.yaml` file contains a project resource with an invalid name.
-    - The `allowed` test case expects `no` violations while the `not_allowed` case expects one or more.
-        - Violations that specifies a `yes` must at least contain one violation that matches the assertion.
-        - Violations with a `no` must not contain any violations that matches the assertion.
-        - If set to a non-negative integer, then exactly that many violations must match. Defaults to "yes".<br><br>
+  - The following elements are important and define most of the suite file.
+    - kind
+    - apiVersion
+    - tests
+    - cases
+    - violations
+  - Set a name for the test suite under metadata - name.
+  - This example only contains two test cases: one for `allowed` values and the other for `not allowed` values.
+  - The `template.yaml` (ConstraintTemplate) and `constraint.yaml` (constraint) files should be in the same folder as the `suite.yaml` file.
+    - The resource manifests contained in the `tests/` folder are evaluated against the constraints set in the `template.yaml` and `constraint.yaml` files.
+  - Tests are manifest files containing example projects and are placed under `tests/`.
+    - The `tests/project_allowed.yaml` manifest contains a project resource with a valid name while the `tests/project_not_allowed.yaml` file contains a project resource with an invalid name.
+  - The `allowed` test case expects `no` violations while the `not_allowed` case expects one or more.
+    - Violations that specifies a `yes` must at least contain one violation that matches the assertion.
+    - Violations with a `no` must not contain any violations that matches the assertion.
+    - If set to a non-negative integer, then exactly that many violations must match. Defaults to "yes".
 
     ```yaml
     kind: Suite
@@ -254,7 +257,7 @@ The following steps can be used to create a test suite:
 - Create a folder called `tests` and place resource manifest files containing the gcp resource(s) being evaluated.
 - Your folder structure should be similar to this:
 
-    ```
+    ```shell
     .
     ├── Kptfile
     ├── README.md
@@ -266,7 +269,8 @@ The following steps can be used to create a test suite:
         ├── project_allowed.yaml
         └── project_not_allowed.yaml
     ```
-- This example only expects one valid (allowed) value and one bad (not_allowed) value. The `tests/project_allowed.yaml` manifest contains a project resource with a valid name while the `tests/project_not_allowed.yaml` file contains a project resouce with an invalid name.
+
+- This example only expects one valid (allowed) value and one bad (not_allowed) value. The `tests/project_allowed.yaml` manifest contains a project resource with a valid name while the `tests/project_not_allowed.yaml` file contains a project resource with an invalid name.
 
     project_allowed.yaml
 
@@ -295,11 +299,12 @@ The following steps can be used to create a test suite:
     spec:
       name: zzxyq-pe-test-projectA
     ```
+
 - Test using `gator verify suite.yaml`
 
     **Note:** The output below as been edited for clarity.
 
-    ```
+    ```shell
     $ pwd
     gcp-blueprints-catalog/gatekeeper-policies/naming-rules/project
     $ gator verify suite.  yaml

--- a/Landing Zone Operations/Building.md
+++ b/Landing Zone Operations/Building.md
@@ -8,74 +8,92 @@ This document will highlight the discrepancies instead of repeating the full pro
 
 **We recommend that you read the entire procedure before initiating it**
 
-**Important** SSC is using Azure Devops Repositories and Pipelines as it's git solution.
+**Important** SSC is using Azure Devops Repositories and Pipelines as its git solution.
 
-# [Organization](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/solutions/landing-zone-v2/README.md#Organization)
-Shared Services Canada uses the "Multiple GCP organizations" achitecture.
+## [Organization](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/solutions/landing-zone-v2/README.md#Organization)
 
-# Setup
-## 1. Complete the boostrap procedure
+Shared Services Canada uses the "Multiple GCP organizations" architecture.
+
+## Setup
+
+## 1. Complete the bootstrap procedure
+
 - Step: Create firewall rules
-    
+
     make sure you implement the allow-egress-azure rule
 
 ## 2. Create your landing zone
+
 - Step : Customize Packages
-    
+
     **DO NOT customize** the packages
 
 ## 3. Deploy the infrastructure using either kpt or gitops-git or gitops-oci
+
 ****This procedure completely overrides the procedure on Google's pubsec repo.**
 
 As you saw in the [Gitops](../Architecture/Repository%20Structure.md#Gitops) diagram, the ConfigSync operator requires an Infra repo and a ConfigSync repo. To do so, we implement a [Gitops-Git](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/landing-zone-v2#gitops---git) deployment.
 
 ### Infra repo
+
 This section will implement the Infra repo
+
 1. Create a new `tier1-infra` repo in your Azure Devops project
     - Experimentation
-          
+
         repo name = `gcp-experimentation-tier1-infra`
     - DEV, PREPROD, PROD
 
         repo name = `gcp-tier1-infra`
 1. Clone locally the `gcp-repo-template` in order to build the new `tier1-infra` repo
     - Experimentation
-      ```bash
+
+      ```shell
       git clone https://github.com/ssc-spc-ccoe-cei/gcp-repo-template.git gcp-experimentation-tier1-infra
       ```
-    
+
     - DEV, PREPROD, PROD
-        ```bash
+
+        ```shell
         git clone https://github.com/ssc-spc-ccoe-cei/gcp-repo-template.git gcp-tier1-infra
         ```
+
 1. Move into the new folder corresponding to that repo
     - Experimentation
-        ```bash
+
+        ```shell
         cd gcp-experimentation-tier1-infra
         ```
+
     - DEV, PREPROD, PROD
-        ```bash
+
+        ```shell
         cd gcp-tier1-infra
         ```
+
 1. Change repo upstream
-    ```bash
+
+    ```shell
     # Remove the origin pointing to the template repo
     git remote remove origin
     # Add the new origin with your repo url
     git remote add origin <YOUR NEW REPO URL>
     ```
+
 1. Generate and store a `.env` file
 
-    In order to keep track of the variables that were used when building this landing zone, we recommend that you generate a `.env` file that includes the variables and values that were used when executing the `## 1. Complete the boostrap procedure`
+    In order to keep track of the variables that were used when building this landing zone, we recommend that you generate a `.env` file that includes the variables and values that were used when executing the `## 1. Complete the bootstrap procedure`
 
     Generate that file and copy it into this `tier1-infra` repo under the folder `bootstrap/<env>`
 
 1. Copy the landing-zone folder created when performing `2. Create your landing zone` to this new repo/source-base.
-    ```bash
+
+    ```shell
     copy -R ../landing-zone source-base
     ```
+
 1. Customize the landing zone package and all of it subpackages
-    
+
     Refer to the `Add a Package` section of the [Changing.md](Changing.md)
 
 1. Generate hydrated files
@@ -83,49 +101,62 @@ This section will implement the Infra repo
     Refer to the `Hydrate` section of the [Changing.md](Changing.md)
 
 1. Add changes to repository
-    
+
     Refer to the `Publish` section of the [Changing.md](Changing.md).
-    
+
     **You will need to push to main when running git push**
-    
+
     `git push --set-upstream origin main`
 
 1. Excellent ! You have completed your `tier1-infra` repository
 
 ### ConfigSync
+
 The ConfigSync operator requires a ConfigSync repo to identify what version of the `tier1-infra` it should observe. To implement this, we will :
+
 1. Create a ConfigSync repo.
 2. Create a git-creds secret.
 3. Deploy a root-sync to config controller.
 
-### 1. Create a ConfigSync repo.
+### 1. Create a ConfigSync repo
+
 1. Create a new `gcp-tier1-configsync` repo in your Azure Devops project
 
 1. Clone locally the repository template repo in order to build the new `gcp-tier1-configsync`
-    ```bash
+
+    ```shell
     git clone https://github.com/ssc-spc-ccoe-cei/gcp-repo-template.git gcp-tier1-configsync
     ```
+
 1. Move into the new folder corresponding to that repo
-    ```bash
+
+    ```shell
     cd gcp-tier1-configsync
     ```
+
 1. Change repo upstream
-    ```bash
+
+    ```shell
     # Remove the origin pointing to the template repo
     git remote remove origin
     # Add the new origin with your repo url
     git remote add origin <YOUR NEW REPO URL>
-    ```  
+    ```
+
 1. Move into the `source-base` folder
-    ```bash
+
+    ```shell
     cd source-base
     ```
+
 1. Get the root-sync kpt package
-    ```bash
+
+    ```shell
     TODO: kpt pkg get URL ./tier1-root-sync
     ```
+
 1. Customize the root-sync package
-    
+
     Refer to the `Add a Package` section of the [Changing.md](Changing.md)
 
 1. Generate hydrated files
@@ -133,39 +164,47 @@ The ConfigSync operator requires a ConfigSync repo to identify what version of t
     Refer to the `Hydrate` section of the [Changing.md](Changing.md)
 
 1. Add changes to repository
-    
+
     Refer to the `Publish` section of the [Changing.md](Changing.md).
-    
+
     **You will need to push to main when running git push**
-    
+
     `git push --set-upstream origin main`
 
 1. Excellent ! You have completed your `tier1-configsync` repository
 
-### 2. Create a git-creds secret.
+### 2. Create a git-creds secret
+
 Now that the `tier1-configsync` repo is ready, we need to tell the ConfigSync operator to observe it. In this step, you will create a kubernetes secret that grants "code read" permission on `tier1-infra` and `tier1-configsync` repo.
-1. Ensure your envrionment still have these variables define
-    ```
+
+1. Ensure your environment still have these variables define
+
+    ```shell
     echo $GIT_USERNAME
     echo $TOKEN
     ```
+
     If not, run this
-    ```
+
+    ```shell
     export GIT_USERNAME=<git username> # For Azure Devops, this is the name of the Organization
     export TOKEN=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     ```
 
-1. Create `git-creds` secret with the required value to access the git repositories    
-    ```bash
+1. Create `git-creds` secret with the required value to access the git repositories
+
+    ```shell
     kubectl create secret generic git-creds --namespace="config-management-system" --from-literal=username=${GIT_USERNAME} --from-literal=token=${TOKEN}
     ```
 
-### 3. Deploy a root-sync to config controller.
+### 3. Deploy a root-sync to config controller
+
 Now let's deploy that first root-sync that will make the magic happen and get your landing zone deployed in GCP.
 
 1. Configure the `RootSync` object
 
     Create a file using the example below
+
     ```yaml
     cat <<EOF>> root-sync.yaml
     apiVersion: configsync.gke.io/v1beta1
@@ -187,19 +226,24 @@ Now let's deploy that first root-sync that will make the magic happen and get yo
     ```
 
 1. Deploy the Config Sync Manifest
-    ```bash
+
+    ```shell
     kubectl apply -f root-sync.yaml
     kubectl wait --for condition=established --timeout=10s crd/rootsyncs.configsync.gke.io
     ```
+
 1. Store root-sync.yaml file in `tier1-infra` repo
 
     In order to keep track of that root-sync.yaml manual deployment that was used when building this landing zone, we recommend that you store this file into the `tier1-infra` repo under the folder `bootstrap/<env>`. This file will not be used in any way, it is just a reference.
 
-# 4. Validate the landing zone deployment
+## 4. Validate the landing zone deployment
+
 Perform this procedure as described
 
-# 5. Perform the post-deployment steps
+## 5. Perform the post-deployment steps
+
 Perform this procedure as described
 
-# THE END
+## THE END
+
 Congratulations! You have completed the deployment of your landing zone as per SSC implementation.

--- a/Landing Zone Operations/Building_Using_Automation.md
+++ b/Landing Zone Operations/Building_Using_Automation.md
@@ -8,8 +8,9 @@ This document will describe how the automated scripts can be used for building a
 
 **Important** SSC is using Azure Devops Repositories and Pipelines as its git solution.
 
-# Requirements
-Shared Services Canada uses the "[Multiple GCP organizations](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/landing-zone-v2/README.md#multiple-gcp-organizations)" achitecture.
+## Requirements
+
+Shared Services Canada uses the "[Multiple GCP organizations](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/landing-zone-v2/README.md#multiple-gcp-organizations)" architecture.
 
 Review the requirements listed [here](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/landing-zone-v2/README.md#requirements).
 
@@ -17,12 +18,13 @@ SSC implements a [Gitops-Git](https://github.com/GoogleCloudPlatform/pubsec-decl
 As illustrated in the [Gitops](../Architecture/Repository%20Structure.md#Gitops) diagram, the ConfigSync operator requires an Infra repo and a ConfigSync repo.
 
 The steps assume these repos have already been created by following the "Create New Deployment Repo" section in [Repositories.md](./Repositories.md):
+
 - One of the two infra repos:
-    - `gcp-experimentation-tier1-infra`: if building a experimentation landing-zone.
-    - `gcp-tier1-infra`: if building a dev, preprod or prod landing-zone.
+  - `gcp-experimentation-tier1-infra`: if building a experimentation landing-zone.
+  - `gcp-tier1-infra`: if building a dev, preprod or prod landing-zone.
 - `gcp-tier1-configsync`: to identify which git revision of `tier1-infra` the Config Sync operator should observe.
 
-# Setup
+## Setup
 
 ## 1. Bootstrap the Config Controller Project
 
@@ -40,24 +42,28 @@ The script requires a `.env` file to deploy the environment.
 1. Your terminal should now be at the root of your `tier1-infra` repo, on a new branch and with the tools submodule populated.
 1. If it doesn't exist, create a `bootstrap/<env>` directory.  It will be used to backup files generated during bootstrapping.
 1. Copy the example.env file from the `tools/scripts/bootstrap` folder.
-    ```bash
+
+    ```shell
     cp tools/scripts/bootstrap/.env.sample bootstrap/<ENV>/.env
     ```
 
-2. **Important** Customize the new file with the approriate values for the landing zone you are building.
+2. **Important** Customize the new file with the appropriate values for the landing zone you are building.
 
 3. Export a `TOKEN` variable.  Set its value to the PAT which has read access to the repo.
-    ```bash
+
+    ```shell
     export TOKEN='xxxxxxxxxxxxxxx'
     ```
 
 1. Run the setup-kcc automated script:
-    ```
+
+    ```shell
     bash tools/scripts/bootstrap/setup-kcc.sh <PATH TO .ENV FILE>
     ```
 
 1. Once the script has completed, you need to move the `root-sync.yaml` file into the `bootstrap/<env>` folder of the `tier1-infra` repo.
-    ```bash
+
+    ```shell
     mv root-sync.yaml bootstrap/<ENV>
     ```
 
@@ -69,11 +75,13 @@ Perform step 4 from this [procedure](https://github.com/GoogleCloudPlatform/pubs
 We will build the landing zone by adding a collection of packages to the `tier1-infra` repo.
 
 ### Add Packages
+
 Follow step 2A "Add a Package" of [Changing.md](./Changing.md) to add each of these packages:
 
 1. The landing zone package:
     - Package details:
-        ```bash
+
+        ```shell
         export REPO_URI='https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git'
 
         export PKG_PATH='solutions/landing-zone-v2'
@@ -83,13 +91,17 @@ Follow step 2A "Add a Package" of [Changing.md](./Changing.md) to add each of th
 
         export LOCAL_DEST_DIRECTORY='landing-zone'
         ```
+
     - Customization:
-        ```bash
+
+        ```shell
         export FILE_TO_CUSTOMIZE='landing-zone/setters.yaml'
         ```
+
 1. The hierarchy package:
     - Package details:
-        ```bash
+
+        ```shell
         export REPO_URI='https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git'
 
         # for experimentation
@@ -103,14 +115,17 @@ Follow step 2A "Add a Package" of [Changing.md](./Changing.md) to add each of th
 
         export LOCAL_DEST_DIRECTORY='landing-zone/hierarchy'
         ```
+
     - Customization:
-        ```bash
+
+        ```shell
         export FILE_TO_CUSTOMIZE='landing-zone/hierarchy/setters.yaml'
         ```
 
 1. The Gatekeeper policies package:
     - Package details:
-        ```bash
+
+        ```shell
         export REPO_URI='https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git'
 
         export PKG_PATH='solutions/gatekeeper-policies'
@@ -120,14 +135,17 @@ Follow step 2A "Add a Package" of [Changing.md](./Changing.md) to add each of th
 
         export LOCAL_DEST_DIRECTORY='landing-zone/gatekeeper-policies'
         ```
+
     - Customization:
-        ```bash
+
+        ```shell
         export FILE_TO_CUSTOMIZE='landing-zone/gatekeeper-policies/naming-rules/project/setters.yaml'
         ```
 
 1. The organization policies package:
     - Package details:
-        ```bash
+
+        ```shell
         export REPO_URI='https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git'
 
         export PKG_PATH='solutions/org-policies'
@@ -137,10 +155,13 @@ Follow step 2A "Add a Package" of [Changing.md](./Changing.md) to add each of th
 
         export LOCAL_DEST_DIRECTORY='landing-zone/org-policies'
         ```
+
     - Customization:
-        ```bash
+
+        ```shell
         export FILE_TO_CUSTOMIZE='landing-zone/org-policies/setters.yaml'
         ```
+
         For experimentation, you may also want to remove some org policies.
 
 1. The logging package:
@@ -148,6 +169,7 @@ Follow step 2A "Add a Package" of [Changing.md](./Changing.md) to add each of th
     TODO: TBD
 
 ### Complete the Infra Repo
+
 The packages are now added and customized in the `tier1-infra` repo, it's time to hydrate and publish them.
 
 1. Generate hydrated files, follow step 3 "Hydrate" of [Changing.md](./Changing.md).
@@ -157,11 +179,13 @@ The packages are now added and customized in the `tier1-infra` repo, it's time t
 1. Once the PR is merged, note the new tag version or commit SHA.  It will be required in the next section.
 
 ## 3. Synchronize the Landing Zone
+
 Your landing zone is now built and published in the `tier1-infra` repo, but Config Sync is not aware yet.  This is where the `gcp-tier1-configsync` repo comes in to fill the gap by creating a new Root Sync.
 
 1. Follow step 1-4 of [Changing.md](./Changing.md) to **add** the tier1 Root Sync package (step 2A).  If the package already exists from bootstrapping other environments, **modify** it for the new environment (step 2B).
     - Package details:
-        ```bash
+
+        ```shell
         export REPO_URI='TODO: publish package'
 
         export PKG_PATH='TODO: publish package'
@@ -171,6 +195,7 @@ Your landing zone is now built and published in the `tier1-infra` repo, but Conf
 
         export LOCAL_DEST_DIRECTORY='tier1-root-sync'
         ```
+
     - Customization: you will need to customize 2 files.
         > **!!! IMPORTANT !!!** Only customize for the environment your are bootstrapping.
 
@@ -184,14 +209,18 @@ Your landing zone is now built and published in the `tier1-infra` repo, but Conf
 1. Once your PR is merged, Config Sync will pick up the new Root Sync to create.  This new Root Sync will in turn pick up all the resources you have built and hydrated earlier in the `tier1-infra/deploy/<env>` directory.
 
 ## 4. Validate the landing zone deployment
+
 Perform step 4 from this [procedure](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/landing-zone-v2/README.md#4-validate-the-landing-zone-deployment).
 
 You should now see two Root Syncs:
+
 - `root-sync`: to your `...gcp-tier1-configsync/deploy/<env>@main` repo containing 1 rootsync resource which defines...
 - the root sync to your `...tier1-infra/deploy/<env>@<version>` repo containing the landing zone resources.
 
 ## 5. Perform the post-deployment steps
+
 Perform step 5 from this [procedure](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/blob/main/solutions/landing-zone-v2/README.md#5-perform-the-post-deployment-steps).
 
 ## THE END
+
 Congratulations! You have completed the deployment of your landing zone as per SSC implementation.

--- a/Landing Zone Operations/Changing.md
+++ b/Landing Zone Operations/Changing.md
@@ -1,4 +1,5 @@
 # Implementing a change on the landing zone
+
 There can be different types of changes on the landing zone but they all start and end the same way.  This document will go through the different steps.
 
 Before proceeding, you should familiarize yourself with the concepts in "[Repository Structure.md](../Architecture/Repository%20Structure.md)".
@@ -6,34 +7,47 @@ Before proceeding, you should familiarize yourself with the concepts in "[Reposi
 The landing zone solution uses some functionalities of [`kpt`](https://kpt.dev/book/02-concepts/) to manage [packages](https://kpt.dev/book/03-packages/) of YAML configs.
 
 As a high level overview, a package will usually include files that are used specifically by kpt:
+
 - `setters.yaml`: used to set customizable data.
 - `Kptfile`: used to keep track of package versions and [declaratively set which functions](https://kpt.dev/book/04-using-functions/01-declarative-function-execution) should run during rendering. For example, [apply-setters](https://catalog.kpt.dev/apply-setters/v0.2/).
 
 ## Step 1 - Setup
-For any type of change, you should start with a new branch and a clean git working tree (all files are staged and committed).  This will make it easier to visualize changes in [VSCode's Git Source Control](https://code.visualstudio.com/docs/sourcecontrol/overview) (or `git diff`) and revert if needed.  
+
+For any type of change, you should start with a new branch and a clean git working tree (all files are staged and committed).  This will make it easier to visualize changes in [VSCode's Git Source Control](https://code.visualstudio.com/docs/sourcecontrol/overview) (or `git diff`) and revert if needed.
 You can confirm that a working tree is clean by running `git status`.
 
 From your local environment:
+
 1. Clone the repository requiring change:
-    ```bash
+
+    ```shell
     git clone <REPO URL>
     ```
+
 1. Move into the new folder corresponding to that repo:
-    ```bash
+
+    ```shell
     cd <REPO NAME>
     ```
+
 1. Create a new branch, use naming convention if applicable (for example, add issue/work item # in the branch name):
-    ```bash
+
+    ```shell
     git checkout -b <BRANCH NAME>
     ```
+
 1. Run the following to get the proper version of the tools submodule:
-    ```bash
+
+    ```shell
     bash modupdate.sh
     ```
+
 ## Step 2 - Change
+
 There are different types of changes.  Follow the appropriate section for instructions.
 
 ### A) Add a Package
+
 This is accomplished with the [`kpt pkg get`](https://kpt.dev/reference/cli/pkg/get/) command.
 
 As a rule, packages should only be added in a deployment repo's `source-base` folder and **never** manually edited from there.  All customizations are to be made from the `source-customization/<env>` folders.
@@ -41,11 +55,14 @@ As a rule, packages should only be added in a deployment repo's `source-base` fo
 Follow these steps to add a package:
 
 1. Move into the `source-base` folder:
-    ```bash
+
+    ```shell
     cd source-base
     ```
+
 1. You can update and set these variables to make it easier to run subsequent commands:
-    ```bash
+
+    ```shell
     # URI of the git repo containing the package
     # for example, 'https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git'
     export REPO_URI=''
@@ -62,14 +79,18 @@ Follow these steps to add a package:
     # for example, 'landing-zone/hierarchy'
     export LOCAL_DEST_DIRECTORY=''
     ```
+
 1. Add the package with the following command:
-    ```bash
+
+    ```shell
     kpt pkg get ${REPO_URI}/${PKG_PATH}@${VERSION} ${LOCAL_DEST_DIRECTORY}
     ```
+
 1. Review the changes with VSCode's built-in Source Control viewer or by running `git diff`.
-1. Review the package's documentation for specific instructions.  Most will require some sort of customization, such as editing the `setters.yaml`.  
+1. Review the package's documentation for specific instructions.  Most will require some sort of customization, such as editing the `setters.yaml`.
 It will need to be customized for each environment.  This is a manual process, a code snippet like below can help with the initial copy:
-    ```bash
+
+    ```shell
     # the file path to customize, relative to 'source-base'
     # for example, 'landing-zone/org-policies/setters.yaml'
     export FILE_TO_CUSTOMIZE=''
@@ -82,16 +103,18 @@ It will need to be customized for each environment.  This is a manual process, a
         fi
     done
     ```
+
 1. Ensure all files copied under `source-customization` have been edited to reflect each environment.
-    > ***Advanced customization tip.***<br>
-    In some cases, certain resource YAML files may need to be edited for some environments, but not others.  This should be avoided as much as possible because it  complicates the update process.<br>
-    For example, to completely remove a specific org policy from experimentation:<br>
-        - Copy that org policy's YAML file in the experimentation customization folder, ***making sure to maintain the same directory structure***.<br> 
-        - Put the entire file in a comment block.<br>
+    > ***Advanced customization tip.***
+    In some cases, certain resource YAML files may need to be edited for some environments, but not others.  This should be avoided as much as possible because it  complicates the update process.
+    For example, to completely remove a specific org policy from experimentation:
+        - Copy that org policy's YAML file in the experimentation customization folder, ***making sure to maintain the same directory structure***.
+        - Put the entire file in a comment block.
         - The hydration process will then ignore this commented resource definition, effectively removing it.
 1. Review all customizations with VSCode's built-in Source Control viewer or by running `git diff`.  If satisfied, proceed to [Step 3 - Hydrate](#step-3---hydrate).
 
 ### B) Modify a Package
+
 By design, this is accomplished by modifying configs in the `source-customization/<env>`.  Files in other directories should never be modified manually.
 
 ***Standard customization should only involve the `setters.yaml` file.***
@@ -102,9 +125,10 @@ Follow these steps to modify a package:
 1. Once all customizations have been reviewed locally, proceed to [Step 3 - Hydrate](#step-3---hydrate).
 
 ### C) Update a Package
-This is accomplished with the [`kpt pkg update`](https://kpt.dev/reference/cli/pkg/update/) command.  
 
-The default `resource-merge` strategy is usually appropriate but can sometimes omit certain file structure changes (blank line between comments, etc.).  
+This is accomplished with the [`kpt pkg update`](https://kpt.dev/reference/cli/pkg/update/) command.
+
+The default `resource-merge` strategy is usually appropriate but can sometimes omit certain file structure changes (blank line between comments, etc.).
 In these cases, if the structural change is required as part of the update, it may be necessary to *carefully* use the `force-delete-replace` strategy.
 
 A deployment repo's `source-base` folder should always contain unedited packages.  This is where they are also updated.
@@ -114,11 +138,14 @@ A deployment repo's `source-base` folder should always contain unedited packages
 Follow these steps to update a package:
 
 1. Move into the `source-base` folder:
-    ```bash
+
+    ```shell
     cd source-base
     ```
+
 1. You can update and set these variables to make it easier to run subsequent commands:
-    ```bash
+
+    ```shell
     # the folder of the pkg to be updated
     # for example, 'landing-zone/hierarchy'
     export PKG_PATH=''
@@ -127,55 +154,73 @@ Follow these steps to update a package:
     # for example, '0.0.2'
     export VERSION=''
     ```
+
 1. Update the package with the default `resource-merge` strategy:
-    ```bash
+
+    ```shell
     kpt pkg update ${PKG_PATH}@${VERSION}
     ```
+
 1. Review the changes with VSCode's built-in Source Control viewer or by running `git diff`.
 1. If the changes are as expected, proceed to the next step.  Otherwise, you can try these steps:
     1. Revert the changes through VSCode Source Control or by running:
-        ```bash
+
+        ```shell
         git restore .
         ```
+
     1. Update the package with the `force-delete-replace` strategy:
-        ```bash
+
+        ```shell
         kpt pkg update ${PKG_PATH}@${VERSION} --strategy=force-delete-replace
         ```
-    1. Carefully review the changes with VSCode Source Control or by running `git diff`.  
-    Paying close attention that it did not remove something it should not have (local subpackages, etc.). You can easily discard specific changes in VSCode's Source Control or with `git restore <file>`.  
+
+    1. Carefully review the changes with VSCode Source Control or by running `git diff`.
+    Paying close attention that it did not remove something it should not have (local subpackages, etc.). You can easily discard specific changes in VSCode's Source Control or with `git restore <file>`.
     This strategy can also remove or modify `cnrm.cloud.google.com/blueprint:` annotations in many YAML files.  These changes will unfortunately create a large git diff but can be accepted.
     1. If the changes are as expected, proceed to the next step.
-1. For each file under `source-customization/<env>`, verify if it changed in `source-base`.  
+1. For each file under `source-customization/<env>`, verify if it changed in `source-base`.
 For example, if the landing-zone package is updated, compare `source-customization/dev/landing-zone/setters.yaml` with `source-base/landing-zone/setters.yaml`.
     - If a change is detected, manually update the file in `source-customization/<env>`.
 1. Once all customizations have been reviewed locally, proceed to [Step 3 - Hydrate](#step-3---hydrate).
 
 ### D) Remove a Package
+
 This is accomplished by simply deleting the package files in `source-base` and its customizations in `source-customization/<env>`.
 
 > **!!! IMPORTANT !!!** Before deleting a package, confirm that it does not have subpackages that are still needed.
 
 Follow these steps to remove a package:
+
 1. Move into the `source-base` folder:
-    ```bash
+
+    ```shell
     cd source-base
     ```
+
 1. You can update and set these variables to make it easier to run subsequent commands:
-    ```bash
+
+    ```shell
     # the folder of the pkg to be removed
     # for example, 'landing-zone/logging'
     export PKG_PATH=''
     ```
+
 1. Remove the package:
-    ```bash
+
+    ```shell
     rm --recursive ${PKG_PATH}
     ```
+
 1. The package customizations now need to be removed, move to `source-customization`:
-    ```bash
+
+    ```shell
     cd ../source-customization
     ```
+
 1. Remove the customization for each environment:
-    ```bash
+
+    ```shell
     for env_subdir in experimentation dev preprod prod; do
         # check if env. folder exists in source-customization
         if [ -d "${env_subdir}/${PKG_PATH}" ]; then
@@ -183,47 +228,62 @@ Follow these steps to remove a package:
         fi
     done
     ```
+
 1. Review the changes with VSCode's built-in Source Control viewer or by running `git diff`.  If satisfied, proceed to [Step 3 - Hydrate](#step-3---hydrate).
 
 ## Step 3 - Hydrate
+
 This is accomplished with the `hydrate.sh` script located in the tools submodule.  In part, it uses the [`kpt fn render`](https://kpt.dev/reference/cli/fn/render/) command.
 
 > **!!! IMPORTANT !!!** `kpt fn render` should never be executed manually in any directory.  This ensures better package updates and minimizes hydration issues.
 
 In summary, the script will:
+
 - add (`source-base` + `source-customization/<env>`) to `temp-workspace/<env>`
 - then hydrate `temp-workspace/<env>` to `deploy/<env>`
 
 Follow these steps to hydrate your change:
+
 1. Execute the hydration script ***from the root of the repository***:
-    ```bash
+
+    ```shell
     bash tools/scripts/kpt/hydrate.sh
     ```
+
 1. Address errors, if any.
 1. Review the changes with VSCode's built-in Source Control viewer or by running `git diff`, specifically the hydrated files in the `deploy/<env>` folders.  If satisfied, it's time for publishing.
 
 ## Step 4 - Publish
+
 At this point, the changes only exist locally. They are now ready to be published for peer review and approval.
 
 Follow these steps to publish the changes:
+
 1. Prepare your commit by staging the files:
-    ```bash
+
+    ```shell
     git add .
     ```
+
 1. Commit your changes:
-    ```bash
-    git commit -m '<MEANINGFULL MESSAGE GOES HERE>'
+
+    ```shell
+    git commit -m '<MEANINGFUL MESSAGE GOES HERE>'
     ```
+
 1. Push your changes to the repo's origin:
+
     ```bash
     git push --set-upstream origin <branch name>
     ```
+
 1. Create a new [pull requests (PR)](https://learn.microsoft.com/en-us/azure/devops/repos/git/pull-requests?view=azure-devops&tabs=browser) on the repo to merge this `<branch name>` into `main`.
 1. Confirm all required checks are successful (approvals, tests, etc.).  If checks are failing, address them in your local branch then stage, commit and push them to origin.
 1. Complete the pull request once all required checks are successful.
 1. That's it!
 
-# Synchronize / Promote Configs
+## Synchronize / Promote Configs
+
 This section contains additional information on how changes can be promoted between environments.
 
 Changes to `infra` repos will only be applied to GCP when the `configsync` repo is updated.  The concept is similar for all repos

--- a/Landing Zone Operations/Pipelines.md
+++ b/Landing Zone Operations/Pipelines.md
@@ -1,34 +1,40 @@
 # Pipelines
+
 Documentation to manage and configure pipelines.
 
 This documentation assumes that proper YAML files are already committed to the repo. Samples can be found in the [gcp-tools](https://github.com/ssc-spc-ccoe-cei/gcp-tools/tree/main/pipeline-samples/) repo.
 
 ## Azure DevOps YAML Pipelines
+
 The [Azure DevOps pipelines](https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/key-pipelines-concepts?view=azure-devops) need to be manually created using existing YAML definition files located in your repo.  The files could be located in any directory, we'll use the `.azure-pipelines/` directory as a convention.
 
 ### Add Pipeline
+
 Repeat the following steps in Azure DevOps for each YAML pipeline definition files:
 
 Navigate to **Pipelines > Pipelines**:
+
 1. Click the **New pipeline** button.
 1. Select **Azure Repos Git (YAML)**.
 1. Select your repo.
 1. Select **Existing Azure Pipelines YAML file**.
 1. Select the appropriate file in the **Path** dropdown and click **Continue**.
 1. Review the YAML file, click the down arrow next to **Run** and click **Save**.
-1. The pipeline is now added! 
-<br>However, its name defaults to the repo's name which is not ideal if the repo contains multiple pipelines and/or the project contains multiple repos.
-<br>Click the **"three dots" > Rename/move** to provide a meaningful name and optionally move to a folder.
-<br>For example, if your repo's name is `my-repo` and the pipeline YAML file is `firstpipeline.yaml`, the pipeline could be renamed to something like `my-repo__firstpipeline` in a `my-repo` folder.
+1. The pipeline is now added!
+However, its name defaults to the repo's name which is not ideal if the repo contains multiple pipelines and/or the project contains multiple repos.
+Click the **"three dots" > Rename/move** to provide a meaningful name and optionally move to a folder.
+For example, if your repo's name is `my-repo` and the pipeline YAML file is `firstpipeline.yaml`, the pipeline could be renamed to something like `my-repo__firstpipeline` in a `my-repo` folder.
 
 > *During a pipeline’s first execution, it may be required to manually authorize it to use agent pools (depending on security settings) and/or access other resources (repos, variable groups, etc.).*
 
 ### Add PR Trigger
+
 A pipeline may need to run when a Pull Request (PR) is created/updated. In Azure DevOps, this [trigger](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/azure-repos-git?view=azure-devops&tabs=yaml#pr-triggers) cannot be defined in the YAML definitions.  A [build validation policy](https://docs.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#build-validation) must be created to accomplish this.
 
 To do so, for each repo / pipeline requiring a PR trigger:
 
 Navigate to **Project Settings > Repos/Repositories > {repo} > Policies > Branch Policies > main**, click the **“+”** next to **Build Validation** and set the following options:
+
 1. **Build Pipeline**: select the name of the pipeline to trigger on PRs
 1. **Trigger**: *Automatic*
 1. **Policy requirement**: *Required*
@@ -37,17 +43,18 @@ Navigate to **Project Settings > Repos/Repositories > {repo} > Policies > Branch
 
 > *Adding a branch policy will protect the branch.*
 
-
 ### Delete Pipeline
+
 Navigate to **Pipelines > Pipelines**:
+
 1. Find the pipeline to be deleted and click its **"three dots"** on the right side of the screen.
 1. Click **Delete**.
 1. Follow the confirmation prompt.
 
 You can now delete the appropriate YAML file from your repo's `.azure-pipelines` directory.
 
-
 ## GitHub Actions Workflows
+
 Properly formatted YAML file in `.github/workflows` should automatically be added.
 
 Please refer to [GitHub's documentation](https://docs.github.com/en/actions/using-workflows/about-workflows).

--- a/Landing Zone Operations/Repositories.md
+++ b/Landing Zone Operations/Repositories.md
@@ -1,4 +1,5 @@
 # Git Repositories
+
 Documentation to setup and manage git repositories used with Config Sync to deploy GCP resources.
 
 SSC is using Azure Devops Repositories (AzDO Repos) and Pipelines as its git solution.
@@ -7,6 +8,7 @@ SSC implements a [Gitops-Git](https://github.com/GoogleCloudPlatform/pubsec-decl
 As illustrated in the [Gitops](../Architecture/Repository%20Structure.md#Gitops) diagram, the ConfigSync operator requires an Infra repo and a ConfigSync repo.
 
 ## Create New Deployment Repo
+
 Deployment repos are initially created the same way, from cloning [gcp-repo-template](https://github.com/ssc-spc-ccoe-cei/gcp-repo-template.git).  These steps will need to be repeated for each repo name.  For example, `gcp-experimentation-tier1-infra`, `gcp-tier1-configsync`, etc.
 
 The git credentials will need to be appropriately set for your AzDO org.
@@ -18,73 +20,94 @@ The git credentials will need to be appropriately set for your AzDO org.
 1. Create a new **empty** repository (no README.md) to hold the configs in [Azure DevOps](https://docs.microsoft.com/en-us/azure/devops/repos/git/create-new-repo?view=azure-devops).  Once created, copy the HTTPS URL.  It will be required for the next step.
 
 1. Update and export the variables below:
-    ```bash
+
+    ```shell
     export NEW_REPO_NAME='<your new repo name>'
     export NEW_REPO_URL='<your new repo URL>'
     ```
 
 1. Clone the [gcp-repo-template](https://github.com/ssc-spc-ccoe-cei/gcp-repo-template.git) in a folder named like your new repo:
 
-    ```bash
+    ```shell
     git clone https://github.com/ssc-spc-ccoe-cei/gcp-repo-template.git ${NEW_REPO_NAME}
     ```
+
 1. Move into the new folder corresponding to the new repo:
-    ```bash
+
+    ```shell
     cd ${NEW_REPO_NAME}
     ```
+
 1. Change the repo's remote:
-    ```bash
+
+    ```shell
     # Remove the origin pointing to the template repo
     git remote remove origin
     # Add the new origin with your repo url
     git remote add origin ${NEW_REPO_URL}
     ```
+
 1. Confirm the new remote configuration, it should only list your new repo URL for fetch and push:
-    ```bash
+
+    ```shell
     git remote --verbose
     ```
+
 1. Edit `modversions.yaml` to pin the `tools` submodule to a specific [release tag](https://github.com/ssc-spc-ccoe-cei/gcp-tools/releases) or commit SHA.
 1. Run the following to get the proper version of the tools submodule:
-    ```bash
+
+    ```shell
     bash modupdate.sh
     ```
+
 1. Remove pipelines directories which are not required:
     - If the repo is hosted in Azure DevOps:
-        ```bash
+
+        ```shell
         # remove the '.github' pipelines directory
         rm --recursive '.github'
         ```
+
     - If the repo is hosted in GitHub:
-        ```bash
+
+        ```shell
         # remove the '.azure-pipelines' pipelines directory
         rm --recursive '.azure-pipelines'
         ```
+
 1. For **`Infra`** repos, remove the environment sub-directories which are not required. **Never delete '.gitkeep' files in folders that remain.**
     - If the repo is for experimentation. For example, `gcp-experimentation-tier1-infra`:
-        ```bash
+
+        ```shell
         # remove the 'dev', 'preprod' and 'prod' sub-directories
         for env_subdir in dev preprod prod; do
             rm --recursive "deploy/${env_subdir}/"
             rm --recursive "source-customization/${env_subdir}/"
         done
         ```
+
     - If the repo is for dev, preprod and prod. For example, `gcp-tier1-infra`:
-        ```bash
+
+        ```shell
         # remove the 'experimentation' sub-directory
         for env_subdir in experimentation; do
             rm --recursive "deploy/${env_subdir}/"
             rm --recursive "source-customization/${env_subdir}/"
         done
         ```
+
 1. Review your local changes then stage, commit and push them to your new repo.  **You will need to push to main.**
-    ```bash
+
+    ```shell
     git add .
     git commit -m 'initializing repo from template'
     git push --set-upstream origin main
     ```
+
 1. The repo is created! It's now time to protect the main branch.
 
 ### 2. Add Branch Protection
+
 It's recommended to protect the `main` branch and use pull requests for any changes to the repos.
 
 These settings could also be set at the AzDO Project level.
@@ -92,11 +115,13 @@ These settings could also be set at the AzDO Project level.
 At the very least, the [Require a minimum number of reviewers](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies?view=azure-devops&tabs=browser#require_reviewers) branch policy should be enabled on the `main` branch. By doing so, the branch cannot be deleted and changes must be made via pull request.
 
 To enable the policy:
+
 1. Navigate to **Project Settings > Repos/Repositories > {repo} > Policies > Branch Policies > main**
 1. Toggle on **Require a minimum number of reviewers**, the *Minimum number of reviewers* will default to 2.
     - You can also enable *When new changes are pushed:* > *Reset all approval votes*
 
 These other policies can also be enabled as needed:
+
 - **Check for linked work items**: *Required*
 - **Check for comment resolution**: *Required*
 - **Limit merge types**: only allow *Squash merge*
@@ -104,11 +129,13 @@ These other policies can also be enabled as needed:
 > TODO: Extra policy for tier2 "configsync" repos only. "Automatically included reviewers" with path filter on setters-version.yaml
 
 ### 3. Verify Service Account Permissions
+
 An AzDO service account should be used for authenticating Config Sync.  It requires read access to the repo.
 
 Depending on your organization, this could be set at different levels and with groups.  These steps will assume the service account has already been configured.
 
 To confirm:
+
 1. Navigate to **Project Settings > Repos/Repositories > {repo} > Security**.
 1. Find and click on the appropriate service account user or group.
 1. Confirm the **Read** permission is set to **Allow**.  All other permissions should be "Not set" or "Deny".
@@ -116,6 +143,7 @@ To confirm:
 A [personal access token (PAT)](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows) with scope of **Code (Read)** will also need to be created for the service account.  This should only need to be done once per service account.  **Note the expiration date, it will need to be periodically re-generated.**
 
 ### 4. Add Pipelines
+
 The repo is now created and the main branch is protected.  [Pipelines](./Pipelines.md) can be created.
 
 - **All deployment repos should have the `validate-yaml` pipeline.**
@@ -123,11 +151,13 @@ The repo is now created and the main branch is protected.  [Pipelines](./Pipelin
 - To use semantic versioning during deployment operations, the `Infra` repos can be setup with a git tagging pipeline, such as [version-tagging](https://github.com/ssc-spc-ccoe-cei/gcp-tools/tree/main/pipeline-samples/version-tagging).
 
 ## Update Deployment Repo
+
 This section is for updating the deployment repo itself, not the YAML configs.
 
 As with any other change, they should be done through a PR process.
 
 ### Update from Template
+
 The [gcp-repo-template](https://github.com/ssc-spc-ccoe-cei/gcp-repo-template.git) remains fairly static, but it can sometimes contain important changes.
 
 Follow these steps to update your deployment repo with changes from `gcp-repo-template`:
@@ -135,14 +165,18 @@ Follow these steps to update your deployment repo with changes from `gcp-repo-te
 TODO: test and add steps
 
 ### Update `tools` Submodule
+
 The tools submodule can easily be updated to a new version.
 
 Follow these steps to
+
 1. Clone the deployment repo and checkout a new branch.
 1. Edit `modversions.yaml` to pin the `tools` submodule to a new [release tag](https://github.com/ssc-spc-ccoe-cei/gcp-tools/releases) or commit SHA.
 1. Run the following to get the proper version of the tools submodule:
-    ```bash
+
+    ```shell
     bash modupdate.sh
     ```
+
 1. If your repo contains pipelines that were created from `tools/pipeline-samples`, compare the YAML files to see if changes are required.
 1. Stage, commit and push your branch to create a PR.

--- a/Onboarding/Admin.md
+++ b/Onboarding/Admin.md
@@ -8,15 +8,19 @@
 ## Add admin folder(s) to the landing zone repository
 
 1. Move into the landing folder
-    ```
+
+    ```shell
     cd source-base
     ```
+
 1. get the hierarchy/admin-experimentation package
-      ```
+
+      ```shell
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/hierarchy/admin-experimentation@main ./landing-zone/hierarchy/tests/admins/<admin name>
       ```
+
 1. To modify any of the files in this package (like setters.yaml) follow this generic guidance
-  
+
     Refer to the `Add a Package` section of the [Changing.md](Changing.md)
 
 1. Generate hydrated files
@@ -24,5 +28,5 @@
     Refer to the `Hydrate` section of the [Changing.md](Changing.md)
 
 1. Add changes to repository
-    
+
     Refer to the `Publish` section of the [Changing.md](Changing.md)

--- a/Onboarding/Application.md
+++ b/Onboarding/Application.md
@@ -1,6 +1,7 @@
 # Application Onboarding
 
 ## Required Information
+
 ### Common
 
 1. Naming convention for project-id : `<client-code><environment-code><region-code><data-classification>`-`<project-owner>`-`<user defined string>`
@@ -10,17 +11,16 @@
     - environment-code (1 character)
     - region-code (1 character) : "m" projects are always a global/multi-region resource
     - data-classification (1 character): "u" or "a" or "b"
-    - project-owner: string (**total project-id string lenght cannot exceed 30 characters**)
-    - user defined string: string (**total project-id string lenght cannot exceed 30 characters**):
-    
+    - project-owner: string (**total project-id string length cannot exceed 30 characters**)
+    - user defined string: string (**total project-id string length cannot exceed 30 characters**):
+
 1. Billing Account ID to be associated with this project
 
 ### Experimentation
 
 1. user, group or serviceAccount with editor role at project level
-  
-    **user or group has to exist in a Google Cloud Identity (any existing domain)**
 
+    **user or group has to exist in a Google Cloud Identity (any existing domain)**
 
 ### DEV, PREPROD, PROD (UNDER CONSTRUCTION)
 
@@ -35,24 +35,28 @@
 ## Add client's application to the landing zone repository
 
 1. Move into source-base folder
-    ```
+
+    ```shell
     cd source-base
     ```
+
 1. Get the workload package
-    
+
     *Some folders may need to be created beforehand like `<data classification>`
     - Experimentation
-      ```
+
+      ```shell
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/project/project-experimentation@main ./landing-zone/hierarchy/clients/<client name>/applications/<project-id>
       ```
 
     - DEV, PREPROD, PROD
-      ```
+
+      ```shell
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/project/project-experimentation@main ./landing-zone/hierarchy/clients/<client name>/applications/<data classification>/<project-id>
       ```
 
 1. To modify any of the files in this package (like setters.yaml) follow this generic guidance
-  
+
     Refer to the `Add a Package` section of the [Changing.md](Changing.md)
 
 1. Generate hydrated files
@@ -60,5 +64,5 @@
     Refer to the `Hydrate` section of the [Changing.md](Changing.md)
 
 1. Add changes to repository
-    
+
     Refer to the `Publish` section of the [Changing.md](Changing.md)

--- a/Onboarding/Client.md
+++ b/Onboarding/Client.md
@@ -10,7 +10,7 @@
    ![folder](img/departments-and-agencies-en-ssc.png)
 
    ![folder](img/departments-and-agencies-fr-spc.png)
-    
+
    In order to uphold folder name requirements in the Google Cloud Console ([Creating and managing folders](https://cloud.google.com/resource-manager/docs/creating-managing-folders#:~:text=For%20example%2C%20to%20create%20folders,%2C%20spaces%2C%20hyphens%20and%20underscores)), avoid using accented characters in French.
 
     ![folder](img/folder-structure-ssc-spc.png)
@@ -19,8 +19,8 @@
 
     ![folder](img/folder-structure-ssc-spc.png)
 
-
 ### TODO: Future enhancement
+
 1. User or Group that should be granted `Essential Contacts` Admin role on the client's folder structure
 
     ![folder](img/essential-contacts.png)
@@ -32,27 +32,29 @@
 1. locally clone the landing zone repo for this environment
 1. create a branch from main
 
-
-
 ## Add client folder(s) to the landing zone repository
 
 1. Move into source-base folder
-    ```
+
+    ```shell
     cd source-base
     ```
+
 1. Get the hierarchy/client package
     - Experimentation
-      ```
+
+      ```shell
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/hierarchy/client-experimentation@main ./landing-zone/hierarchy/clients/<client name>
       ```
 
     - DEV, PREPROD, PROD
-      ```
+
+      ```shell
       kpt pkg get https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit.git/solutions/hierarchy/client-env@main ./landing-zone/hierarchy/clients/<client name>
       ```
 
 1. To modify any of the files in these packages (like setters.yaml) follow this generic guidance
-  
+
     Refer to the `Add a Package` section of the [Changing.md](Changing.md)
 
 1. Generate hydrated files
@@ -60,11 +62,9 @@
     Refer to the `Hydrate` section of the [Changing.md](Changing.md)
 
 1. Add changes to repository
-    
-    Refer to the `Publish` section of the [Changing.md](Changing.md)
 
+    Refer to the `Publish` section of the [Changing.md](Changing.md)
 
 ## Add client Tier2-ConfigSync (DEV, PREPROD, PROD only) (UNDER CONSTRUCTION)
 
 TODO: complete this steps
-


### PR DESCRIPTION
* Resolved ~890 style issues identified across ~18 markdown files
* Introduced ‘shell’ for all fenced-code-language blocks
* Corrected ~17 spelling errors, outside code and resource names
