### PR TITLE
aligned .markdown-lint-config.yaml with gcp-tools and pubsec-declarative-toolkit repos, linted README.MD

### DIFF
--- a/.github/linter-rules/.markdown-lint-config.yaml
+++ b/.github/linter-rules/.markdown-lint-config.yaml
@@ -18,15 +18,15 @@
 MD004: false                  # Unordered list style
 MD007:
   indent: 2                   # Unordered list indentation
-MD013:
-  line_length: 600            # Line length 80 is far too short
+MD012: false                  # Multiple consecutive blank lines - workaround to accommodate CHANGELOG.md files that are generated and maintained by release-please
+MD013: false                  # Line length (longest single line previously seen was 741 characters)
 MD024: false                  # no-duplicate-header, fails on CHANGELOG.md
 MD026:
   punctuation: ".,;:!。，；:"  # List of not allowed
 MD029: false                  # Ordered list item prefix
+MD030: false                  # disable list-marker-space, generate kpt docs would make it fail
 MD033: false                  # Allow inline HTML
 MD036: false                  # Emphasis used instead of a heading
-MD040: false                  # disable "Fenced code blocks should have a language specified"
 
 #################
 # Rules by tags #

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -26,6 +26,11 @@ jobs:
           # list of changed files within `super-linter`
           fetch-depth: 0
 
+      ################################
+      # Run Linter against code base
+      # each step will run even if one fails
+      # this is accomplished with the 'if: ${{ success() || failure() }}'
+      ################################
       # Super-Linter markdown validation
       - name: Lint Markdown
         if: ${{ success() || failure() }}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -26,21 +26,13 @@ jobs:
           # list of changed files within `super-linter`
           fetch-depth: 0
 
-      ################################
-      # Run Linter against code base
-      # each step will run even if one fails
-      # this is accomplished with the 'if: ${{ success() || failure() }}'
-      ################################
-      # TODO: once all markdown errors have been fixed:
-      #   1. set 'VALIDATE_ALL_CODEBASE: false'
-      #   2. remove 'DISABLE_ERRORS: true'
+      # Super-Linter markdown validation
       - name: Lint Markdown
         if: ${{ success() || failure() }}
         uses: github/super-linter/slim@v4
         env:
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           LINTER_RULES_PATH: .github/linter-rules
           VALIDATE_MARKDOWN: true
           MARKDOWN_CONFIG_FILE: .markdown-lint-config.yaml
-          DISABLE_ERRORS: true

--- a/README.MD
+++ b/README.MD
@@ -1,4 +1,5 @@
+# README
+
 Shared Services Canada has built an enterprise virtual datacenter in Google Cloud to host workloads from any of the 43 departments of Government of Canada. These workloads are integrated into what we call a **Landing Zone**.
 
 This repo will demonstrate how SSC implemented the Landing zone v2 solution available [here](https://github.com/GoogleCloudPlatform/pubsec-declarative-toolkit/tree/main/solutions/landing-zone-v2) in order to achieve **Day 0, 1 and 2** operations.
-


### PR DESCRIPTION
* Aligned .markdown-lint-config.yaml with GitHub gcp-tools and pubsec-declarative-toolkit repos
* Linted gcp-documentation/README.md (MD041 - 'First line in a file should be a top-level heading')
* Aligned gcp-documentation/.github/linter-rules/workflows/linter.yaml with GitHub gcp-tools and pubsec-declarative-toolkit repos